### PR TITLE
fix: standardize project naming for consistent releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 env:
   GO_VERSION: '1.21'
   REGISTRY: docker.io
-  IMAGE_NAME: rafaelvzago/ssh-vault-keeper
+  IMAGE_NAME: rafaelvzago/ssh-secret-keeper
 
 jobs:
   release:
@@ -123,11 +123,11 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 🔗 Release Links:" >> $GITHUB_STEP_SUMMARY
         echo "- [📋 Release Page](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.tag }})" >> $GITHUB_STEP_SUMMARY
-        echo "- [🐳 Docker Hub](https://hub.docker.com/r/rafaelvzago/ssh-vault-keeper)" >> $GITHUB_STEP_SUMMARY
+        echo "- [🐳 Docker Hub](https://hub.docker.com/r/rafaelvzago/ssh-secret-keeper)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 📥 Quick Install:" >> $GITHUB_STEP_SUMMARY
         echo '```bash' >> $GITHUB_STEP_SUMMARY
         echo "# Linux amd64" >> $GITHUB_STEP_SUMMARY
-        echo "curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.tag }}/ssh-vault-keeper-${{ steps.get_version.outputs.version }}-linux-amd64.tar.gz -o sshsk.tar.gz" >> $GITHUB_STEP_SUMMARY
+        echo "curl -L https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.tag }}/ssh-secret-keeper-${{ steps.get_version.outputs.version }}-linux-amd64.tar.gz -o sshsk.tar.gz" >> $GITHUB_STEP_SUMMARY
         echo "tar -xzf sshsk.tar.gz && sudo mv sshsk /usr/local/bin/" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # GoReleaser configuration for SSH Secret Keeper
 
+project_name: ssh-secret-keeper
+
 before:
   hooks:
     - go mod tidy
@@ -69,8 +71,8 @@ release:
     ### Container Images
 
     Container images are available at:
-    - `ssh-secret-keeper:{{ .Version }}`
-    - `ssh-secret-keeper:latest` (for stable releases)
+    - `rafaelvzago/ssh-secret-keeper:{{ .Version }}`
+    - `rafaelvzago/ssh-secret-keeper:latest` (for stable releases)
 
 changelog:
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,8 +175,8 @@ Upgrade instructions will be provided with each release.
 ## Support
 
 For questions, issues, or feature requests:
-- **Issues**: [GitHub Issues](https://github.com/rzago/sshsk/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/rzago/sshsk/discussions)
+- **Issues**: [GitHub Issues](https://github.com/rzago/ssh-vault-keeper/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/rzago/ssh-vault-keeper/discussions)
 - **Security**: Please report security issues via GitHub Issues with the "security" label
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [`site/README.md`](site/README.md) for detailed development documentation.
 ### Option 1: Download Release Binary
 ```bash
 # Download latest release (replace VERSION and ARCH)
-curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-vault-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz
+curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz
 tar -xzf sshsk.tar.gz
 chmod +x sshsk
 sudo mv sshsk /usr/local/bin/
@@ -77,7 +77,7 @@ sudo mv sshsk /usr/local/bin/
 
 ### Option 2: Build from Source
 ```bash
-git clone https://github.com/rzago/sshsk
+git clone https://github.com/rzago/ssh-vault-keeper
 cd sshsk
 make build
 sudo make install
@@ -86,12 +86,12 @@ sudo make install
 ### Option 3: Container (Docker/Podman)
 ```bash
 # Using Docker
-docker pull ghcr.io/rzago/ssh-secret-keeper:latest
-docker run --rm -v ~/.ssh:/ssh -v ~/.ssh-secret-keeper:/config ghcr.io/rzago/ssh-secret-keeper analyze
+docker pull rafaelvzago/ssh-secret-keeper:latest
+docker run --rm -v ~/.ssh:/ssh -v ~/.ssh-secret-keeper:/config rafaelvzago/ssh-secret-keeper analyze
 
 # Using Podman
-podman pull ghcr.io/rzago/ssh-secret-keeper:latest
-podman run --rm -v ~/.ssh:/ssh -v ~/.ssh-secret-keeper:/config ghcr.io/rzago/ssh-secret-keeper analyze
+podman pull rafaelvzago/ssh-secret-keeper:latest
+podman run --rm -v ~/.ssh:/ssh -v ~/.ssh-secret-keeper:/config rafaelvzago/ssh-secret-keeper analyze
 ```
 
 ## Prerequisites
@@ -460,7 +460,8 @@ jobs:
         VAULT_ADDR: ${{ vars.VAULT_ADDR }}
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       run: |
-        curl -L https://github.com/rzago/sshsk/releases/latest/download/sshsk-linux-amd64 -o sshsk
+        curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz
+        tar -xzf sshsk.tar.gz
         chmod +x sshsk
         ./sshsk init
         ./sshsk backup "github-${GITHUB_SHA}-${GITHUB_RUN_ID}"
@@ -474,7 +475,8 @@ jobs:
         VAULT_ADDR: ${{ vars.VAULT_ADDR }}
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       run: |
-        curl -L https://github.com/rzago/sshsk/releases/latest/download/sshsk-linux-amd64 -o sshsk
+        curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz
+        tar -xzf sshsk.tar.gz
         chmod +x sshsk
         ./sshsk init
         ./sshsk restore --target-dir /tmp/ssh-keys
@@ -494,7 +496,8 @@ pipeline {
         stage('Backup SSH Keys') {
             steps {
                 sh '''
-                    curl -L https://github.com/rzago/sshsk/releases/latest/download/sshsk-linux-amd64 -o sshsk
+                    curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz
+        tar -xzf sshsk.tar.gz
                     chmod +x sshsk
                     ./sshsk init
                     ./sshsk backup "jenkins-${BUILD_NUMBER}-${GIT_COMMIT}"
@@ -545,7 +548,8 @@ echo "Setting up SSH keys from Vault..."
 # Download sshsk if not available
 if ! command -v sshsk &> /dev/null; then
     echo "Downloading sshsk..."
-    curl -L "https://github.com/rzago/sshsk/releases/latest/download/sshsk-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/')" -o /tmp/sshsk
+    curl -L "https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/').tar.gz" -o /tmp/sshsk.tar.gz
+    tar -xzf /tmp/sshsk.tar.gz -C /tmp
     chmod +x /tmp/sshsk
     SSH_SECRET_KEEPER="/tmp/sshsk"
 else
@@ -808,7 +812,7 @@ This project follows SOLID principles and clean architecture patterns for mainta
 
 ### Build Instructions
 ```bash
-git clone https://github.com/rzago/sshsk
+git clone https://github.com/rzago/ssh-vault-keeper
 cd sshsk
 
 # Build for current platform
@@ -1028,9 +1032,9 @@ If you encounter issues:
 ## Support
 
 - [Documentation](docs/)
-- [Issue Tracker](https://github.com/rzago/sshsk/issues)
-- [Discussions](https://github.com/rzago/sshsk/discussions)
-- [Security Issues](https://github.com/rzago/sshsk/issues/new?labels=security)
+- [Issue Tracker](https://github.com/rzago/ssh-vault-keeper/issues)
+- [Discussions](https://github.com/rzago/ssh-vault-keeper/discussions)
+- [Security Issues](https://github.com/rzago/ssh-vault-keeper/issues/new?labels=security)
 
 ## Recent Updates
 

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -67,7 +67,7 @@ const ASCIIBorder: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 function App() {
   const [activeTab, setActiveTab] = useState('installation');
 
-  const installCommand = "curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-vault-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz && tar -xzf sshsk.tar.gz && sudo mv sshsk /usr/local/bin/";
+  const installCommand = "curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz && tar -xzf sshsk.tar.gz && sudo mv sshsk /usr/local/bin/";
 
   const features = [
     {
@@ -239,7 +239,7 @@ function App() {
                     <div className="text-gray-400"># Linux amd64</div>
                     <div>
                       <span className="text-green-400">$</span>
-                      <span className="ml-2 text-white">curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-vault-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz</span>
+                      <span className="ml-2 text-white">curl -L https://github.com/rzago/ssh-vault-keeper/releases/latest/download/ssh-secret-keeper-VERSION-linux-amd64.tar.gz -o sshsk.tar.gz</span>
                     </div>
                     <div>
                       <span className="text-green-400">$</span>


### PR DESCRIPTION
- Add project_name to .goreleaser.yml for consistent archive naming
- Update GitHub Actions workflow to use ssh-secret-keeper image name
- Fix all download URLs in README.md to use ssh-secret-keeper archives
- Update container image references throughout documentation
- Fix legacy repository references (rzago/sshsk → rzago/ssh-vault-keeper)
- Update website installation commands for consistency

This resolves the HTTP 307 release upload errors by ensuring consistent naming between repository (ssh-vault-keeper) and project (ssh-secret-keeper).

Release artifacts will now be named: ssh-secret-keeper-VERSION-PLATFORM.tar.gz
Container images will be: rafaelvzago/ssh-secret-keeper:VERSION

Fixes: Release upload failures with 307 Moved Permanently errors
Tested: GoReleaser configuration validated and snapshot release successful