### PR TITLE
Update installation URLs to use refs/heads/main format

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,22 @@ See [`site/README.md`](site/README.md) for detailed development documentation.
 ### Option 1: Quick Installation Script (Recommended)
 ```bash
 # Quick installation - detects your OS and installs automatically
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
 ```
 
 **Installation Options:**
 ```bash
 # Install to user directory (no sudo required)
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --user
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --user
 
 # Install specific version
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --version 1.2.0
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --version 1.2.0
 
 # Install to custom directory
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --install-dir /opt/bin
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --install-dir /opt/bin
 
 # View all options
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --help
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --help
 ```
 
 The installation script:
@@ -489,7 +489,7 @@ jobs:
         VAULT_ADDR: ${{ vars.VAULT_ADDR }}
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       run: |
-        curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+        curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
         sshsk init
         sshsk backup "github-${GITHUB_SHA}-${GITHUB_RUN_ID}"
 
@@ -502,7 +502,7 @@ jobs:
         VAULT_ADDR: ${{ vars.VAULT_ADDR }}
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       run: |
-        curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+        curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
         sshsk init
         sshsk restore --target-dir /tmp/ssh-keys
 ```
@@ -521,7 +521,7 @@ pipeline {
         stage('Backup SSH Keys') {
             steps {
                 sh '''
-                    curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+                    curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
                     sshsk init
                     sshsk backup "jenkins-${BUILD_NUMBER}-${GIT_COMMIT}"
                 '''
@@ -571,7 +571,7 @@ echo "Setting up SSH keys from Vault..."
 # Install sshsk if not available
 if ! command -v sshsk &> /dev/null; then
     echo "Installing sshsk..."
-    curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+    curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
     SSH_SECRET_KEEPER="sshsk"
 else
     SSH_SECRET_KEEPER="sshsk"

--- a/docs/INSTALLATION_SCRIPT.md
+++ b/docs/INSTALLATION_SCRIPT.md
@@ -21,23 +21,23 @@ The installation script provides an automated, cross-platform way to install SSH
 
 ```bash
 # Install latest version (system-wide, requires sudo)
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
 ```
 
 ### Installation Options
 
 ```bash
 # Install to user directory (no sudo required)
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --user
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --user
 
 # Install specific version
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --version 1.2.0
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --version 1.2.0
 
 # Install to custom directory
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --install-dir /opt/bin
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --install-dir /opt/bin
 
 # View help
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --help
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --help
 ```
 
 ### Local Installation
@@ -140,7 +140,7 @@ The script provides comprehensive error handling with clear messages:
 Enable debug mode for troubleshooting:
 
 ```bash
-curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --debug
+curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --debug
 ```
 
 Debug mode provides:
@@ -188,18 +188,18 @@ The installation script is perfect for CI/CD environments:
 ### GitHub Actions
 ```yaml
 - name: Install SSH Secret Keeper
-  run: curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+  run: curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
 ```
 
 ### GitLab CI
 ```yaml
 before_script:
-  - curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+  - curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
 ```
 
 ### Jenkins
 ```groovy
-sh 'curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash'
+sh 'curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash'
 ```
 
 ## Testing
@@ -224,7 +224,7 @@ Run tests:
 1. **Permission denied**:
    ```bash
    # Try user installation
-   curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash -s -- --user
+   curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash -s -- --user
    ```
 
 2. **Network issues**:
@@ -236,7 +236,7 @@ Run tests:
 3. **Checksum failures**:
    ```bash
    # Retry installation (might be temporary network issue)
-   curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/raw/main/install.sh | bash
+   curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash
    ```
 
 4. **Platform not supported**:

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -68,7 +68,7 @@ const ASCIIBorder: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 function App() {
   const [activeTab, setActiveTab] = useState('installation');
 
-  const installCommand = "curl -sSL https://github.com/rafaelvzago/ssh-secret-keeper/install.sh | bash";
+  const installCommand = "curl -sSL https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh | bash";
 
   const features = [
     {

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -12,8 +12,8 @@ export const config = {
     url: 'https://github.com/rafaelvzago/ssh-secret-keeper',
   },
   install: {
-    scriptUrl: 'https://github.com/rafaelvzago/ssh-secret-keeper/install.sh',
-    rawScriptUrl: 'https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/main/install.sh',
+    scriptUrl: 'https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh',
+    rawScriptUrl: 'https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh',
     downloadBase: 'https://github.com/rafaelvzago/ssh-secret-keeper/releases/latest/download/',
   },
   docker: {


### PR DESCRIPTION
- Update site/src/App.tsx installCommand to use standardized URL
- Update site/src/config.ts scriptUrl and rawScriptUrl consistently
- Update all curl commands in README.md (9 occurrences)
- Update all curl commands in docs/INSTALLATION_SCRIPT.md (12 occurrences)
- Standardize all installation instructions to use: https://raw.githubusercontent.com/rafaelvzago/ssh-secret-keeper/refs/heads/main/install.sh
- Improves consistency and reliability across all documentation