### PR TITLE
feat: add self-update command with system-wide installation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,11 +23,39 @@ func main() {
 		return
 	}
 
-	// Load configuration
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading configuration: %v\n", err)
-		os.Exit(1)
+	// Check if this is a command that doesn't need Vault configuration
+	skipConfigCommands := map[string]bool{
+		"version":    true,
+		"update":     true,
+		"help":       true,
+		"completion": true,
+	}
+
+	var cfg *config.Config
+
+	// Check for help flags
+	isHelpCommand := false
+	if len(os.Args) > 1 {
+		for _, arg := range os.Args[1:] {
+			if arg == "--help" || arg == "-h" || arg == "help" {
+				isHelpCommand = true
+				break
+			}
+		}
+	}
+
+	// Only load full configuration if not a skip-config command or help
+	if isHelpCommand || (len(os.Args) > 1 && skipConfigCommands[os.Args[1]]) {
+		// Use default config for commands that don't need Vault
+		cfg = config.Default()
+	} else {
+		// Load full configuration including Vault validation
+		var err error
+		cfg, err = config.Load()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading configuration: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Set log level from config

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -51,6 +51,7 @@ flexible backup/restore operations.`,
 		newMigrateCommand(cfg),
 		newMigrateStatusCommand(cfg),
 		newVersionCommand(),
+		newUpdateCommand(cfg),
 	)
 
 	return rootCmd

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/rzago/ssh-secret-keeper/internal/config"
+	"github.com/rzago/ssh-secret-keeper/internal/update"
+	"github.com/spf13/cobra"
+)
+
+// newUpdateCommand creates the update command
+func newUpdateCommand(cfg *config.Config) *cobra.Command {
+	var opts update.UpdateOptions
+	var checkOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update SSH Secret Keeper to the latest version",
+		Long: `Check for and install updates to SSH Secret Keeper.
+
+This command will:
+1. Check for the latest release on GitHub
+2. Download the appropriate binary for your platform
+3. Verify the download integrity
+4. Create a backup of the current binary
+5. Replace the binary with the new version
+
+Examples:
+  # Check for updates without installing
+  sshsk update --check
+
+  # Update to the latest stable version
+  sshsk update
+
+  # Update to a specific version
+  sshsk update --version v1.0.5
+
+  # Include pre-release versions
+  sshsk update --pre-release
+
+  # Force reinstall even if already on latest
+  sshsk update --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Set up update configuration
+			updateConfig := &update.UpdateConfig{
+				GitHubRepo: "rafaelvzago/ssh-secret-keeper",
+			}
+
+			// Override with config if available
+			if cfg != nil && cfg.Update != nil {
+				updateConfig = &update.UpdateConfig{
+					CheckOnStartup: cfg.Update.CheckOnStartup,
+					AutoUpdate:     cfg.Update.AutoUpdate,
+					Channel:        cfg.Update.Channel,
+					CheckInterval:  cfg.Update.CheckInterval,
+					GitHubRepo:     cfg.Update.GitHubRepo,
+				}
+			}
+
+			// Create update service
+			service := update.NewService(updateConfig)
+
+			// Get current version
+			currentVersion := Version
+			if currentVersion == "" || currentVersion == "dev" {
+				currentVersion = "v0.0.0" // Use a base version for dev builds
+			}
+
+			// Check only mode
+			if checkOnly {
+				return checkForUpdates(cmd, service, currentVersion, opts.PreRelease)
+			}
+
+			// Check for updates first
+			status, err := service.CheckForUpdates(currentVersion, opts.PreRelease)
+			if err != nil {
+				return fmt.Errorf("failed to check for updates: %w", err)
+			}
+
+			// Display update information
+			displayUpdateStatus(cmd, status)
+
+			if !status.UpdateAvailable && !opts.Force {
+				cmd.Println("\n✅ You are already on the latest version!")
+				return nil
+			}
+
+			// Ask for confirmation in interactive mode
+			if !opts.Force && !confirmUpdate(cmd, status) {
+				cmd.Println("Update cancelled.")
+				return nil
+			}
+
+			// Perform the update
+			cmd.Println("\n🚀 Starting update process...")
+
+			// Set the options for check-only mode
+			opts.CheckOnly = checkOnly
+
+			if err := service.Update(currentVersion, opts); err != nil {
+				return fmt.Errorf("update failed: %w", err)
+			}
+
+			cmd.Printf("\n✨ Successfully updated to %s!\n", status.LatestVersion)
+			cmd.Println("Please restart any running sshsk processes to use the new version.")
+
+			return nil
+		},
+	}
+
+	// Add flags
+	cmd.Flags().StringVar(&opts.Version, "version", "", "Update to specific version")
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Check for updates without installing")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Force update even if already on latest")
+	cmd.Flags().BoolVar(&opts.PreRelease, "pre-release", false, "Include pre-release versions")
+	cmd.Flags().BoolVar(&opts.NoBackup, "no-backup", false, "Don't create backup of current binary")
+	cmd.Flags().BoolVar(&opts.SkipChecksum, "skip-checksum", false, "Skip checksum verification (not recommended)")
+	cmd.Flags().BoolVar(&opts.SkipVerify, "skip-verify", false, "Skip new binary verification")
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+// checkForUpdates checks for available updates and displays the result
+func checkForUpdates(cmd *cobra.Command, service *update.Service, currentVersion string, includePreRelease bool) error {
+	cmd.Println("🔍 Checking for updates...")
+
+	status, err := service.CheckForUpdates(currentVersion, includePreRelease)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	displayUpdateStatus(cmd, status)
+
+	if status.UpdateAvailable {
+		cmd.Println("\n📦 An update is available!")
+		cmd.Println("Run 'sshsk update' to install the latest version.")
+	} else {
+		cmd.Println("\n✅ You are on the latest version!")
+	}
+
+	return nil
+}
+
+// displayUpdateStatus displays the update status information
+func displayUpdateStatus(cmd *cobra.Command, status *update.UpdateStatus) {
+	cmd.Printf("\n📌 Current version: %s\n", formatVersion(status.CurrentVersion))
+	cmd.Printf("🎯 Latest version:  %s", formatVersion(status.LatestVersion))
+
+	if !status.PublishedAt.IsZero() {
+		age := time.Since(status.PublishedAt)
+		cmd.Printf(" (released %s)\n", formatUpdateDuration(age))
+	} else {
+		cmd.Println()
+	}
+
+	if status.UpdateAvailable {
+		cmd.Println("🆕 Update available: Yes")
+
+		// Show release notes if available
+		if status.ReleaseNotes != "" {
+			cmd.Println("\n📝 Release Notes:")
+			displayReleaseNotes(cmd, status.ReleaseNotes)
+		}
+	} else {
+		cmd.Println("🆕 Update available: No")
+	}
+}
+
+// displayReleaseNotes formats and displays release notes
+func displayReleaseNotes(cmd *cobra.Command, notes string) {
+	lines := strings.Split(notes, "\n")
+	maxLines := 10
+	displayed := 0
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Indent the line
+		cmd.Printf("   %s\n", line)
+
+		displayed++
+		if displayed >= maxLines {
+			remaining := len(lines) - displayed
+			if remaining > 0 {
+				cmd.Printf("   ... and %d more lines\n", remaining)
+			}
+			break
+		}
+	}
+}
+
+// confirmUpdate asks the user for confirmation
+func confirmUpdate(cmd *cobra.Command, status *update.UpdateStatus) bool {
+	// Check if --yes flag was provided
+	if yes, _ := cmd.Flags().GetBool("yes"); yes {
+		return true
+	}
+
+	// Check if we're in a non-interactive environment
+	if !isInteractive() {
+		log.Debug().Msg("Non-interactive environment detected, skipping confirmation")
+		return true
+	}
+
+	cmd.Printf("\nDo you want to update to %s? (y/N): ", status.LatestVersion)
+
+	var response string
+	fmt.Scanln(&response)
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
+}
+
+// isInteractive checks if we're running in an interactive terminal
+func isInteractive() bool {
+	// Check if stdin is a terminal
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
+// formatVersion formats a version string for display
+func formatVersion(version string) string {
+	if version == "" {
+		return "unknown"
+	}
+	if version == "dev" {
+		return "dev (development build)"
+	}
+	return version
+}
+
+// formatUpdateDuration formats a duration for human-readable display
+func formatUpdateDuration(d time.Duration) string {
+	if d < time.Hour {
+		return fmt.Sprintf("%d minutes ago", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%d hours ago", int(d.Hours()))
+	}
+	days := int(d.Hours() / 24)
+	if days == 1 {
+		return "1 day ago"
+	}
+	if days < 30 {
+		return fmt.Sprintf("%d days ago", days)
+	}
+	if days < 365 {
+		months := days / 30
+		if months == 1 {
+			return "1 month ago"
+		}
+		return fmt.Sprintf("%d months ago", months)
+	}
+	years := days / 365
+	if years == 1 {
+		return "1 year ago"
+	}
+	return fmt.Sprintf("%d years ago", years)
+}

--- a/internal/update/downloader.go
+++ b/internal/update/downloader.go
@@ -1,0 +1,225 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Downloader handles downloading and extracting release assets
+type Downloader struct {
+	httpClient *http.Client
+	tempDir    string
+}
+
+// NewDownloader creates a new downloader
+func NewDownloader() *Downloader {
+	return &Downloader{
+		httpClient: &http.Client{
+			Timeout: 5 * time.Minute, // Longer timeout for downloads
+		},
+		tempDir: os.TempDir(),
+	}
+}
+
+// DownloadAsset downloads an asset to a temporary file
+func (d *Downloader) DownloadAsset(asset *Asset, progress func(downloaded, total int64)) (string, error) {
+	// Create temporary file
+	tempFile, err := os.CreateTemp(d.tempDir, "sshsk-update-*.tar.gz")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer tempFile.Close()
+
+	tempPath := tempFile.Name()
+
+	log.Info().
+		Str("url", asset.BrowserDownloadURL).
+		Str("file", filepath.Base(tempPath)).
+		Int64("size", asset.Size).
+		Msg("Downloading update")
+
+	// Download the file
+	resp, err := d.httpClient.Get(asset.BrowserDownloadURL)
+	if err != nil {
+		os.Remove(tempPath)
+		return "", fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		os.Remove(tempPath)
+		return "", fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	// Create progress reader if callback provided
+	var reader io.Reader = resp.Body
+	if progress != nil {
+		reader = &progressReader{
+			reader:   resp.Body,
+			total:    asset.Size,
+			callback: progress,
+		}
+	}
+
+	// Copy to temp file
+	written, err := io.Copy(tempFile, reader)
+	if err != nil {
+		os.Remove(tempPath)
+		return "", fmt.Errorf("failed to write download: %w", err)
+	}
+
+	log.Debug().
+		Int64("bytes", written).
+		Str("file", tempPath).
+		Msg("Download completed")
+
+	return tempPath, nil
+}
+
+// ExtractBinary extracts the binary from a tar.gz archive
+func (d *Downloader) ExtractBinary(archivePath string, platform Platform) (string, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer file.Close()
+
+	// Create gzip reader
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gzReader.Close()
+
+	// Create tar reader
+	tarReader := tar.NewReader(gzReader)
+
+	// Look for the binary
+	binaryName := GetBinaryName(platform)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to read tar: %w", err)
+		}
+
+		// Check if this is our binary
+		if filepath.Base(header.Name) == binaryName {
+			// Create temp file for binary
+			tempBinary, err := os.CreateTemp(d.tempDir, "sshsk-new-*")
+			if err != nil {
+				return "", fmt.Errorf("failed to create temp binary: %w", err)
+			}
+
+			tempPath := tempBinary.Name()
+
+			// Copy binary content
+			_, err = io.Copy(tempBinary, tarReader)
+			tempBinary.Close()
+
+			if err != nil {
+				os.Remove(tempPath)
+				return "", fmt.Errorf("failed to extract binary: %w", err)
+			}
+
+			// Set executable permissions
+			if err := os.Chmod(tempPath, 0755); err != nil {
+				os.Remove(tempPath)
+				return "", fmt.Errorf("failed to set permissions: %w", err)
+			}
+
+			log.Debug().
+				Str("binary", binaryName).
+				Str("extracted_to", tempPath).
+				Msg("Binary extracted successfully")
+
+			return tempPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("binary %s not found in archive", binaryName)
+}
+
+// VerifyChecksum verifies the SHA256 checksum of a file
+func (d *Downloader) VerifyChecksum(filePath, expectedChecksum string) error {
+	if expectedChecksum == "" {
+		log.Warn().Msg("No checksum provided, skipping verification")
+		return nil
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file for checksum: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("failed to calculate checksum: %w", err)
+	}
+
+	actualChecksum := fmt.Sprintf("%x", hash.Sum(nil))
+
+	if !strings.EqualFold(actualChecksum, expectedChecksum) {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, actualChecksum)
+	}
+
+	log.Debug().
+		Str("checksum", actualChecksum[:16]+"...").
+		Msg("Checksum verified successfully")
+
+	return nil
+}
+
+// CleanupTempFiles removes temporary files created during download
+func (d *Downloader) CleanupTempFiles() {
+	// Clean up any sshsk-update-* or sshsk-new-* files in temp dir
+	pattern := filepath.Join(d.tempDir, "sshsk-*")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		log.Debug().Err(err).Msg("Failed to list temp files for cleanup")
+		return
+	}
+
+	for _, file := range files {
+		if strings.Contains(file, "sshsk-update-") || strings.Contains(file, "sshsk-new-") {
+			if err := os.Remove(file); err != nil {
+				log.Debug().Err(err).Str("file", file).Msg("Failed to remove temp file")
+			} else {
+				log.Debug().Str("file", file).Msg("Cleaned up temp file")
+			}
+		}
+	}
+}
+
+// progressReader wraps an io.Reader and reports progress
+type progressReader struct {
+	reader     io.Reader
+	total      int64
+	downloaded int64
+	callback   func(downloaded, total int64)
+}
+
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.reader.Read(p)
+	pr.downloaded += int64(n)
+
+	if pr.callback != nil {
+		pr.callback(pr.downloaded, pr.total)
+	}
+
+	return n, err
+}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -1,0 +1,228 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultGitHubRepo = "rafaelvzago/ssh-secret-keeper"
+	githubAPIBase     = "https://api.github.com"
+	githubTimeout     = 30 * time.Second
+)
+
+// GitHubClient handles communication with GitHub API
+type GitHubClient struct {
+	repo       string
+	httpClient *http.Client
+}
+
+// NewGitHubClient creates a new GitHub API client
+func NewGitHubClient(repo string) *GitHubClient {
+	if repo == "" {
+		repo = defaultGitHubRepo
+	}
+
+	return &GitHubClient{
+		repo: repo,
+		httpClient: &http.Client{
+			Timeout: githubTimeout,
+		},
+	}
+}
+
+// GetLatestRelease fetches the latest release from GitHub
+func (c *GitHubClient) GetLatestRelease(includePreRelease bool) (*Release, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", githubAPIBase, c.repo)
+
+	if includePreRelease {
+		// If including pre-releases, we need to get all releases and find the latest
+		return c.getLatestFromAllReleases()
+	}
+
+	log.Debug().Str("url", url).Msg("Fetching latest release from GitHub")
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add headers
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "ssh-secret-keeper-updater")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to decode release: %w", err)
+	}
+
+	return &release, nil
+}
+
+// GetReleaseByTag fetches a specific release by tag
+func (c *GitHubClient) GetReleaseByTag(tag string) (*Release, error) {
+	// Clean the tag
+	if !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/releases/tags/%s", githubAPIBase, c.repo, tag)
+
+	log.Debug().Str("url", url).Str("tag", tag).Msg("Fetching release by tag from GitHub")
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "ssh-secret-keeper-updater")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release %s not found", tag)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to decode release: %w", err)
+	}
+
+	return &release, nil
+}
+
+// getLatestFromAllReleases gets the latest release including pre-releases
+func (c *GitHubClient) getLatestFromAllReleases() (*Release, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases", githubAPIBase, c.repo)
+
+	log.Debug().Str("url", url).Msg("Fetching all releases from GitHub")
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "ssh-secret-keeper-updater")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch releases: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var releases []Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("failed to decode releases: %w", err)
+	}
+
+	if len(releases) == 0 {
+		return nil, fmt.Errorf("no releases found")
+	}
+
+	// Return the first one (most recent)
+	return &releases[0], nil
+}
+
+// FindAssetForPlatform finds the appropriate asset for the given platform
+func (c *GitHubClient) FindAssetForPlatform(release *Release, platform Platform) (*Asset, error) {
+	expectedName := GetAssetName(platform, release.TagName)
+
+	log.Debug().
+		Str("platform", fmt.Sprintf("%s-%s", platform.OS, platform.Arch)).
+		Str("expected_asset", expectedName).
+		Int("total_assets", len(release.Assets)).
+		Msg("Looking for platform-specific asset")
+
+	for _, asset := range release.Assets {
+		if asset.Name == expectedName {
+			return &asset, nil
+		}
+	}
+
+	// List available assets for debugging
+	var available []string
+	for _, asset := range release.Assets {
+		available = append(available, asset.Name)
+	}
+
+	return nil, fmt.Errorf("no asset found for platform %s-%s (expected: %s, available: %s)",
+		platform.OS, platform.Arch, expectedName, strings.Join(available, ", "))
+}
+
+// GetChecksumForAsset fetches the checksum for a specific asset
+func (c *GitHubClient) GetChecksumForAsset(release *Release, assetName string) (string, error) {
+	// Look for checksums.txt in the assets
+	var checksumAsset *Asset
+	for _, asset := range release.Assets {
+		if asset.Name == "checksums.txt" {
+			checksumAsset = &asset
+			break
+		}
+	}
+
+	if checksumAsset == nil {
+		log.Warn().Msg("No checksums.txt file found in release assets")
+		return "", nil // Return empty string if no checksum file
+	}
+
+	// Download the checksum file
+	resp, err := c.httpClient.Get(checksumAsset.BrowserDownloadURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to download checksums: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download checksums (status %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read checksums: %w", err)
+	}
+
+	// Parse checksums file (format: "checksum  filename")
+	lines := strings.Split(string(body), "\n")
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) >= 2 && parts[1] == assetName {
+			return parts[0], nil
+		}
+	}
+
+	log.Warn().Str("asset", assetName).Msg("Checksum not found for asset")
+	return "", nil
+}

--- a/internal/update/platform.go
+++ b/internal/update/platform.go
@@ -1,0 +1,135 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// DetectPlatform returns the current platform information
+func DetectPlatform() Platform {
+	return Platform{
+		OS:   runtime.GOOS,
+		Arch: runtime.GOARCH,
+	}
+}
+
+// GetBinaryName returns the expected binary name for the platform
+func GetBinaryName(platform Platform) string {
+	if platform.OS == "windows" {
+		return "sshsk.exe"
+	}
+	return "sshsk"
+}
+
+// GetAssetName returns the expected asset name for a platform
+func GetAssetName(platform Platform, version string) string {
+	// Format: ssh-secret-keeper-{version}-{os}-{arch}.tar.gz
+	// Example: ssh-secret-keeper-1.0.4-linux-amd64.tar.gz
+	cleanVersion := strings.TrimPrefix(version, "v")
+	return fmt.Sprintf("ssh-secret-keeper-%s-%s-%s.tar.gz",
+		cleanVersion, platform.OS, platform.Arch)
+}
+
+// GetCurrentBinaryPath returns the path to the currently running binary
+func GetCurrentBinaryPath() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	// Resolve any symlinks
+	realPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		// If we can't resolve symlinks, use the original path
+		log.Debug().Err(err).Msg("Could not resolve symlinks, using original path")
+		return execPath, nil
+	}
+
+	return realPath, nil
+}
+
+// GetInstallDir returns the directory where the binary is installed
+func GetInstallDir() (string, error) {
+	binaryPath, err := GetCurrentBinaryPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(binaryPath), nil
+}
+
+// CanWriteToBinary checks if we have permission to update the binary
+func CanWriteToBinary() error {
+	binaryPath, err := GetCurrentBinaryPath()
+	if err != nil {
+		return fmt.Errorf("failed to get binary path: %w", err)
+	}
+
+	// Check if we can write to the binary location
+	dir := filepath.Dir(binaryPath)
+	testFile := filepath.Join(dir, ".sshsk-update-test")
+
+	// Try to create a test file
+	file, err := os.Create(testFile)
+	if err != nil {
+		return fmt.Errorf("insufficient permissions to update binary in %s: %w", dir, err)
+	}
+	file.Close()
+
+	// Clean up test file
+	os.Remove(testFile)
+
+	return nil
+}
+
+// GetBackupPath returns the path for backing up the current binary
+func GetBackupPath() (string, error) {
+	binaryPath, err := GetCurrentBinaryPath()
+	if err != nil {
+		return "", err
+	}
+	return binaryPath + ".backup", nil
+}
+
+// IsSystemInstall checks if the binary is installed in a system directory
+func IsSystemInstall() bool {
+	binaryPath, err := GetCurrentBinaryPath()
+	if err != nil {
+		return false
+	}
+
+	systemDirs := []string{
+		"/usr/local/bin",
+		"/usr/bin",
+		"/opt",
+		"C:\\Program Files",
+	}
+
+	for _, dir := range systemDirs {
+		if strings.HasPrefix(binaryPath, dir) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// RequiresSudo checks if sudo/admin privileges might be required for update
+func RequiresSudo() bool {
+	if runtime.GOOS == "windows" {
+		// On Windows, check if in Program Files
+		binaryPath, err := GetCurrentBinaryPath()
+		if err != nil {
+			return false
+		}
+		return strings.Contains(binaryPath, "Program Files")
+	}
+
+	// On Unix-like systems, check if we can write
+	err := CanWriteToBinary()
+	return err != nil
+}

--- a/internal/update/platform_test.go
+++ b/internal/update/platform_test.go
@@ -1,0 +1,121 @@
+package update
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDetectPlatform(t *testing.T) {
+	platform := DetectPlatform()
+
+	if platform.OS != runtime.GOOS {
+		t.Errorf("DetectPlatform().OS = %s, want %s", platform.OS, runtime.GOOS)
+	}
+
+	if platform.Arch != runtime.GOARCH {
+		t.Errorf("DetectPlatform().Arch = %s, want %s", platform.Arch, runtime.GOARCH)
+	}
+}
+
+func TestGetBinaryName(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform Platform
+		expected string
+	}{
+		{
+			"Linux binary",
+			Platform{OS: "linux", Arch: "amd64"},
+			"sshsk",
+		},
+		{
+			"macOS binary",
+			Platform{OS: "darwin", Arch: "arm64"},
+			"sshsk",
+		},
+		{
+			"Windows binary",
+			Platform{OS: "windows", Arch: "amd64"},
+			"sshsk.exe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetBinaryName(tt.platform)
+			if result != tt.expected {
+				t.Errorf("GetBinaryName(%v) = %s, want %s",
+					tt.platform, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAssetName(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform Platform
+		version  string
+		expected string
+	}{
+		{
+			"Linux amd64",
+			Platform{OS: "linux", Arch: "amd64"},
+			"v1.0.4",
+			"ssh-secret-keeper-1.0.4-linux-amd64.tar.gz",
+		},
+		{
+			"macOS arm64",
+			Platform{OS: "darwin", Arch: "arm64"},
+			"v1.0.4",
+			"ssh-secret-keeper-1.0.4-darwin-arm64.tar.gz",
+		},
+		{
+			"Windows amd64",
+			Platform{OS: "windows", Arch: "amd64"},
+			"1.0.4",
+			"ssh-secret-keeper-1.0.4-windows-amd64.tar.gz",
+		},
+		{
+			"Linux arm64",
+			Platform{OS: "linux", Arch: "arm64"},
+			"v2.0.0",
+			"ssh-secret-keeper-2.0.0-linux-arm64.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAssetName(tt.platform, tt.version)
+			if result != tt.expected {
+				t.Errorf("GetAssetName(%v, %s) = %s, want %s",
+					tt.platform, tt.version, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetBackupPath(t *testing.T) {
+	path, err := GetBackupPath()
+	if err != nil {
+		// This might fail in test environment if binary path can't be determined
+		t.Skipf("GetBackupPath() failed: %v", err)
+	}
+
+	if !strings.HasSuffix(path, ".backup") {
+		t.Errorf("GetBackupPath() = %s, expected to end with .backup", path)
+	}
+}
+
+func TestIsSystemInstall(t *testing.T) {
+	// This test is environment-dependent
+	result := IsSystemInstall()
+	t.Logf("IsSystemInstall() = %v (environment-dependent)", result)
+}
+
+func TestRequiresSudo(t *testing.T) {
+	// This test is environment-dependent
+	result := RequiresSudo()
+	t.Logf("RequiresSudo() = %v (environment-dependent)", result)
+}

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -1,0 +1,396 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Service handles the update process
+type Service struct {
+	github     *GitHubClient
+	downloader *Downloader
+	platform   Platform
+	config     *UpdateConfig
+}
+
+// NewService creates a new update service
+func NewService(config *UpdateConfig) *Service {
+	if config == nil {
+		config = &UpdateConfig{
+			GitHubRepo: defaultGitHubRepo,
+		}
+	}
+
+	return &Service{
+		github:     NewGitHubClient(config.GitHubRepo),
+		downloader: NewDownloader(),
+		platform:   DetectPlatform(),
+		config:     config,
+	}
+}
+
+// CheckForUpdates checks if a new version is available
+func (s *Service) CheckForUpdates(currentVersion string, includePreRelease bool) (*UpdateStatus, error) {
+	log.Info().
+		Str("current_version", currentVersion).
+		Bool("include_prerelease", includePreRelease).
+		Msg("Checking for updates")
+
+	release, err := s.github.GetLatestRelease(includePreRelease)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	latestVersion := FormatVersion(release.TagName)
+	currentVersion = FormatVersion(currentVersion)
+
+	status := &UpdateStatus{
+		CurrentVersion:  currentVersion,
+		LatestVersion:   latestVersion,
+		UpdateAvailable: IsNewer(latestVersion, currentVersion),
+		ReleaseNotes:    release.Body,
+		PublishedAt:     release.PublishedAt,
+	}
+
+	log.Info().
+		Str("current", currentVersion).
+		Str("latest", latestVersion).
+		Bool("update_available", status.UpdateAvailable).
+		Msg("Update check completed")
+
+	return status, nil
+}
+
+// Update performs the update to a specific version or latest
+func (s *Service) Update(currentVersion string, options UpdateOptions) error {
+	// Check permissions first
+	if err := s.checkPermissions(); err != nil {
+		return err
+	}
+
+	// Get the target release
+	var release *Release
+	var err error
+
+	if options.Version != "" {
+		log.Info().Str("version", options.Version).Msg("Updating to specific version")
+		release, err = s.github.GetReleaseByTag(options.Version)
+	} else {
+		log.Info().Bool("prerelease", options.PreRelease).Msg("Updating to latest version")
+		release, err = s.github.GetLatestRelease(options.PreRelease)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to get release: %w", err)
+	}
+
+	targetVersion := FormatVersion(release.TagName)
+	currentVersion = FormatVersion(currentVersion)
+
+	// Check if update is needed
+	if !options.Force && !IsNewer(targetVersion, currentVersion) {
+		log.Info().
+			Str("current", currentVersion).
+			Str("target", targetVersion).
+			Msg("Already on the latest version")
+		return fmt.Errorf("already on version %s (use --force to reinstall)", currentVersion)
+	}
+
+	// Find asset for platform
+	asset, err := s.github.FindAssetForPlatform(release, s.platform)
+	if err != nil {
+		return fmt.Errorf("failed to find release for platform: %w", err)
+	}
+
+	// Get checksum if available
+	var checksum string
+	if !options.SkipChecksum {
+		checksum, err = s.github.GetChecksumForAsset(release, asset.Name)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to get checksum, continuing without verification")
+		}
+	}
+
+	// Download the asset
+	log.Info().Str("version", targetVersion).Msg("Downloading update")
+	archivePath, err := s.downloader.DownloadAsset(asset, s.progressCallback)
+	if err != nil {
+		return fmt.Errorf("failed to download update: %w", err)
+	}
+	defer os.Remove(archivePath)
+
+	// Verify checksum
+	if checksum != "" && !options.SkipChecksum {
+		log.Info().Msg("Verifying checksum")
+		if err := s.downloader.VerifyChecksum(archivePath, checksum); err != nil {
+			return fmt.Errorf("checksum verification failed: %w", err)
+		}
+	}
+
+	// Extract binary
+	log.Info().Msg("Extracting update")
+	newBinaryPath, err := s.downloader.ExtractBinary(archivePath, s.platform)
+	if err != nil {
+		return fmt.Errorf("failed to extract binary: %w", err)
+	}
+	defer os.Remove(newBinaryPath)
+
+	// Verify the new binary works
+	if !options.SkipVerify {
+		log.Info().Msg("Verifying new binary")
+		if err := s.verifyBinary(newBinaryPath); err != nil {
+			return fmt.Errorf("binary verification failed: %w", err)
+		}
+	}
+
+	// Create backup of current binary
+	var backupPath string
+	if !options.NoBackup {
+		backupPath, err = s.createBackup()
+		if err != nil {
+			return fmt.Errorf("failed to create backup: %w", err)
+		}
+		log.Info().Str("backup", backupPath).Msg("Created backup of current binary")
+	}
+
+	// Replace the binary
+	log.Info().Msg("Installing new binary")
+	if err := s.replaceBinary(newBinaryPath); err != nil {
+		// Try to restore backup
+		if backupPath != "" {
+			log.Error().Err(err).Msg("Update failed, restoring backup")
+			if restoreErr := s.restoreBackup(backupPath); restoreErr != nil {
+				log.Error().Err(restoreErr).Msg("Failed to restore backup")
+			}
+		}
+		return fmt.Errorf("failed to install update: %w", err)
+	}
+
+	// Clean up backup after successful update
+	if backupPath != "" {
+		os.Remove(backupPath)
+	}
+
+	// Clean up temp files
+	s.downloader.CleanupTempFiles()
+
+	log.Info().
+		Str("version", targetVersion).
+		Msg("Successfully updated SSH Secret Keeper")
+
+	return nil
+}
+
+// checkPermissions verifies we have permission to update
+func (s *Service) checkPermissions() error {
+	// Check if we can write to /usr/local/bin/
+	targetPath := "/usr/local/bin/sshsk"
+	targetDir := "/usr/local/bin"
+
+	// Try to create a test file in the target directory
+	testFile := filepath.Join(targetDir, ".sshsk-update-test")
+	file, err := os.Create(testFile)
+	if err != nil {
+		// Can't write to /usr/local/bin/, need sudo
+		return fmt.Errorf("insufficient permissions to update %s: try running with sudo", targetPath)
+	}
+	file.Close()
+	os.Remove(testFile)
+
+	return nil
+}
+
+// progressCallback handles download progress reporting
+func (s *Service) progressCallback(downloaded, total int64) {
+	if total <= 0 {
+		return
+	}
+
+	percent := int((downloaded * 100) / total)
+	mb := float64(downloaded) / (1024 * 1024)
+	totalMB := float64(total) / (1024 * 1024)
+
+	// Log progress at intervals
+	if percent%10 == 0 || downloaded == total {
+		log.Debug().
+			Int("percent", percent).
+			Str("progress", fmt.Sprintf("%.1f/%.1f MB", mb, totalMB)).
+			Msg("Download progress")
+	}
+}
+
+// verifyBinary checks that the new binary works
+func (s *Service) verifyBinary(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "version")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf("binary verification failed: %w (output: %s)", err, string(output))
+	}
+
+	// Check that output contains version info
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "SSH Secret Keeper") {
+		return fmt.Errorf("binary verification failed: unexpected output: %s", outputStr)
+	}
+
+	log.Debug().Str("output", strings.TrimSpace(outputStr)).Msg("New binary verified")
+	return nil
+}
+
+// createBackup creates a backup of the current binary
+func (s *Service) createBackup() (string, error) {
+	// Always target /usr/local/bin/sshsk for system-wide updates
+	targetPath := "/usr/local/bin/sshsk"
+
+	// Check if system binary exists
+	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+		// If /usr/local/bin/sshsk doesn't exist, fall back to current binary
+		currentPath, err := GetCurrentBinaryPath()
+		if err != nil {
+			return "", fmt.Errorf("failed to get current binary path: %w", err)
+		}
+		targetPath = currentPath
+	}
+
+	backupPath := targetPath + ".backup"
+
+	// Remove old backup if it exists
+	os.Remove(backupPath)
+
+	// Only create backup if source exists
+	if _, err := os.Stat(targetPath); err == nil {
+		// Copy current binary to backup
+		if err := s.copyFile(targetPath, backupPath); err != nil {
+			return "", fmt.Errorf("failed to create backup: %w", err)
+		}
+	}
+
+	return backupPath, nil
+}
+
+// replaceBinary replaces the current binary with the new one
+func (s *Service) replaceBinary(newBinaryPath string) error {
+	// Always target /usr/local/bin/sshsk for system-wide updates
+	targetPath := "/usr/local/bin/sshsk"
+
+	// Check if target exists, if not use current binary path as fallback
+	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+		// If /usr/local/bin/sshsk doesn't exist, fall back to current binary location
+		currentPath, err := GetCurrentBinaryPath()
+		if err != nil {
+			return fmt.Errorf("failed to get current binary path: %w", err)
+		}
+		targetPath = currentPath
+		log.Debug().Str("path", targetPath).Msg("System binary not found, updating current binary")
+	} else {
+		log.Info().Str("path", targetPath).Msg("Updating system binary")
+	}
+
+	// Get target binary permissions (or use default if new installation)
+	var fileMode os.FileMode = 0755
+	if info, err := os.Stat(targetPath); err == nil {
+		fileMode = info.Mode()
+	}
+
+	// On both Windows and Unix systems, we need to rename the old binary first
+	// Windows: because you can't delete a running executable
+	// Linux/Unix: because you get "text file busy" when writing to a running executable
+	tempPath := targetPath + ".old"
+	os.Remove(tempPath) // Remove if exists
+
+	// Only rename if the target exists
+	if _, err := os.Stat(targetPath); err == nil {
+		if err := os.Rename(targetPath, tempPath); err != nil {
+			return fmt.Errorf("failed to move old binary: %w", err)
+		}
+		defer os.Remove(tempPath)
+	}
+
+	// Copy new binary to target location
+	if err := s.copyFile(newBinaryPath, targetPath); err != nil {
+		// Try to restore the old binary if copy fails
+		if _, err := os.Stat(tempPath); err == nil {
+			os.Rename(tempPath, targetPath)
+		}
+		return fmt.Errorf("failed to copy new binary: %w", err)
+	}
+
+	// Preserve permissions
+	if err := os.Chmod(targetPath, fileMode); err != nil {
+		return fmt.Errorf("failed to set permissions: %w", err)
+	}
+
+	return nil
+}
+
+// restoreBackup restores the backup binary
+func (s *Service) restoreBackup(backupPath string) error {
+	// Always target /usr/local/bin/sshsk for system-wide updates
+	targetPath := "/usr/local/bin/sshsk"
+
+	// Check if we should restore to system location or current binary
+	if _, err := os.Stat(backupPath); err == nil {
+		// If backup is for system location, restore there
+		if strings.HasPrefix(backupPath, "/usr/local/bin/") {
+			targetPath = strings.TrimSuffix(backupPath, ".backup")
+		} else {
+			// Otherwise use current binary location
+			currentPath, err := GetCurrentBinaryPath()
+			if err != nil {
+				return fmt.Errorf("failed to get current binary path: %w", err)
+			}
+			targetPath = currentPath
+		}
+	}
+
+	// On Linux/Unix, we need to handle "text file busy" error
+	// First try to rename the current binary if it exists
+	if _, err := os.Stat(targetPath); err == nil {
+		tempPath := targetPath + ".failed"
+		os.Remove(tempPath) // Remove if exists
+
+		// Try to rename the failed binary
+		if err := os.Rename(targetPath, tempPath); err != nil {
+			// If rename fails, it might be because the binary is still running
+			// In this case, we can't restore the backup while the process is running
+			return fmt.Errorf("cannot restore backup: current binary is still running: %w", err)
+		}
+		defer os.Remove(tempPath)
+	}
+
+	return s.copyFile(backupPath, targetPath)
+}
+
+// copyFile copies a file from src to dst
+func (s *Service) copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = destFile.ReadFrom(sourceFile)
+	return err
+}
+
+// GetPlatformInfo returns information about the current platform
+func (s *Service) GetPlatformInfo() string {
+	return fmt.Sprintf("%s-%s", s.platform.OS, s.platform.Arch)
+}
+
+// SetPlatform allows overriding the detected platform (for testing)
+func (s *Service) SetPlatform(platform Platform) {
+	s.platform = platform
+}

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -1,0 +1,59 @@
+package update
+
+import (
+	"time"
+)
+
+// Release represents a GitHub release
+type Release struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	PublishedAt time.Time `json:"published_at"`
+	Body        string    `json:"body"` // Release notes
+	Assets      []Asset   `json:"assets"`
+}
+
+// Asset represents a release asset (downloadable file)
+type Asset struct {
+	Name               string `json:"name"`
+	Size               int64  `json:"size"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	ContentType        string `json:"content_type"`
+}
+
+// UpdateStatus represents the current update status
+type UpdateStatus struct {
+	CurrentVersion  string
+	LatestVersion   string
+	UpdateAvailable bool
+	ReleaseNotes    string
+	PublishedAt     time.Time
+}
+
+// Platform represents the current system platform
+type Platform struct {
+	OS   string // darwin, linux, windows
+	Arch string // amd64, arm64
+}
+
+// UpdateOptions configures the update behavior
+type UpdateOptions struct {
+	Version      string // Specific version to update to (empty for latest)
+	CheckOnly    bool   // Only check for updates, don't install
+	Force        bool   // Force update even if already on latest
+	PreRelease   bool   // Include pre-release versions
+	NoBackup     bool   // Don't create backup of current binary
+	SkipChecksum bool   // Skip checksum verification (not recommended)
+	SkipVerify   bool   // Skip new binary verification
+}
+
+// UpdateConfig represents update configuration
+type UpdateConfig struct {
+	CheckOnStartup bool          `yaml:"check_on_startup" mapstructure:"check_on_startup"`
+	AutoUpdate     bool          `yaml:"auto_update" mapstructure:"auto_update"`
+	Channel        string        `yaml:"channel" mapstructure:"channel"`
+	CheckInterval  time.Duration `yaml:"check_interval" mapstructure:"check_interval"`
+	GitHubRepo     string        `yaml:"github_repo" mapstructure:"github_repo"`
+}

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -1,0 +1,148 @@
+package update
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CompareVersions compares two semantic versions
+// Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
+func CompareVersions(v1, v2 string) int {
+	// Clean version strings
+	v1 = cleanVersion(v1)
+	v2 = cleanVersion(v2)
+
+	// Split into parts
+	parts1 := parseVersion(v1)
+	parts2 := parseVersion(v2)
+
+	// Compare major.minor.patch
+	for i := 0; i < 3; i++ {
+		if i >= len(parts1) && i >= len(parts2) {
+			break
+		}
+
+		p1 := 0
+		if i < len(parts1) {
+			p1 = parts1[i]
+		}
+
+		p2 := 0
+		if i < len(parts2) {
+			p2 = parts2[i]
+		}
+
+		if p1 > p2 {
+			return 1
+		} else if p1 < p2 {
+			return -1
+		}
+	}
+
+	// Check for pre-release versions
+	pre1 := extractPreRelease(v1)
+	pre2 := extractPreRelease(v2)
+
+	// If one has pre-release and other doesn't
+	if pre1 != "" && pre2 == "" {
+		return -1 // v1 is pre-release, v2 is stable
+	}
+	if pre1 == "" && pre2 != "" {
+		return 1 // v1 is stable, v2 is pre-release
+	}
+
+	// Both have pre-release or both don't
+	if pre1 != "" && pre2 != "" {
+		return strings.Compare(pre1, pre2)
+	}
+
+	return 0
+}
+
+// IsNewer checks if version v1 is newer than v2
+func IsNewer(v1, v2 string) bool {
+	return CompareVersions(v1, v2) > 0
+}
+
+// cleanVersion removes 'v' prefix and cleans the version string
+func cleanVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	version = strings.TrimPrefix(version, "V")
+	return version
+}
+
+// parseVersion parses a version string into major, minor, patch numbers
+func parseVersion(version string) []int {
+	// Remove any pre-release or metadata
+	if idx := strings.Index(version, "-"); idx != -1 {
+		version = version[:idx]
+	}
+	if idx := strings.Index(version, "+"); idx != -1 {
+		version = version[:idx]
+	}
+
+	parts := strings.Split(version, ".")
+	result := make([]int, 0, 3)
+
+	for i, part := range parts {
+		if i >= 3 {
+			break // Only consider major.minor.patch
+		}
+
+		num, err := strconv.Atoi(part)
+		if err != nil {
+			num = 0
+		}
+		result = append(result, num)
+	}
+
+	return result
+}
+
+// extractPreRelease extracts pre-release identifier from version
+func extractPreRelease(version string) string {
+	if idx := strings.Index(version, "-"); idx != -1 {
+		endIdx := len(version)
+		if plusIdx := strings.Index(version[idx:], "+"); plusIdx != -1 {
+			endIdx = idx + plusIdx
+		}
+		return version[idx+1 : endIdx]
+	}
+	return ""
+}
+
+// FormatVersion ensures consistent version formatting
+func FormatVersion(version string) string {
+	version = cleanVersion(version)
+	if !strings.HasPrefix(version, "v") && version != "dev" && version != "" {
+		version = "v" + version
+	}
+	return version
+}
+
+// ValidateVersion checks if a version string is valid
+func ValidateVersion(version string) error {
+	if version == "" {
+		return fmt.Errorf("version cannot be empty")
+	}
+
+	if version == "dev" || version == "latest" {
+		return nil // Special cases
+	}
+
+	cleaned := cleanVersion(version)
+	parts := parseVersion(cleaned)
+
+	if len(parts) == 0 {
+		return fmt.Errorf("invalid version format: %s", version)
+	}
+
+	// Check that we have at least major.minor
+	if len(parts) < 2 {
+		return fmt.Errorf("version must have at least major.minor: %s", version)
+	}
+
+	return nil
+}

--- a/internal/update/version_test.go
+++ b/internal/update/version_test.go
@@ -1,0 +1,130 @@
+package update
+
+import (
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		// Basic version comparisons
+		{"Equal versions", "1.0.0", "1.0.0", 0},
+		{"v1 newer patch", "1.0.1", "1.0.0", 1},
+		{"v2 newer patch", "1.0.0", "1.0.1", -1},
+		{"v1 newer minor", "1.1.0", "1.0.0", 1},
+		{"v2 newer minor", "1.0.0", "1.1.0", -1},
+		{"v1 newer major", "2.0.0", "1.0.0", 1},
+		{"v2 newer major", "1.0.0", "2.0.0", -1},
+
+		// With v prefix
+		{"With v prefix equal", "v1.0.0", "v1.0.0", 0},
+		{"With v prefix v1 newer", "v1.0.1", "v1.0.0", 1},
+		{"Mixed v prefix", "v1.0.1", "1.0.0", 1},
+
+		// Pre-release versions
+		{"Pre-release vs stable", "1.0.0-beta", "1.0.0", -1},
+		{"Stable vs pre-release", "1.0.0", "1.0.0-beta", 1},
+		{"Pre-release comparison", "1.0.0-beta.2", "1.0.0-beta.1", 1},
+		{"Pre-release alpha vs beta", "1.0.0-beta", "1.0.0-alpha", 1},
+
+		// Different lengths
+		{"Missing patch v1", "1.0", "1.0.0", 0},
+		{"Missing patch v2", "1.0.0", "1.0", 0},
+		{"Missing minor and patch", "2", "1.9.9", 1},
+
+		// Edge cases
+		{"Dev version", "dev", "1.0.0", -1},
+		{"Empty vs version", "", "1.0.0", -1},
+		{"Large numbers", "10.20.30", "9.99.99", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CompareVersions(tt.v1, tt.v2)
+			if result != tt.expected {
+				t.Errorf("CompareVersions(%s, %s) = %d, want %d",
+					tt.v1, tt.v2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"Newer patch", "1.0.1", "1.0.0", true},
+		{"Older patch", "1.0.0", "1.0.1", false},
+		{"Equal", "1.0.0", "1.0.0", false},
+		{"Newer major", "2.0.0", "1.9.9", true},
+		{"Pre-release", "1.0.0", "1.0.0-beta", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNewer(tt.v1, tt.v2)
+			if result != tt.expected {
+				t.Errorf("IsNewer(%s, %s) = %v, want %v",
+					tt.v1, tt.v2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Add v prefix", "1.0.0", "v1.0.0"},
+		{"Keep v prefix", "v1.0.0", "v1.0.0"},
+		{"Dev version", "dev", "dev"},
+		{"Empty version", "", ""},
+		{"Capital V", "V1.0.0", "v1.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatVersion(tt.input)
+			if result != tt.expected {
+				t.Errorf("FormatVersion(%s) = %s, want %s",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{"Valid semver", "1.0.0", false},
+		{"Valid with v", "v1.0.0", false},
+		{"Valid major.minor", "1.0", false},
+		{"Dev version", "dev", false},
+		{"Latest version", "latest", false},
+		{"Invalid empty", "", true},
+		{"Invalid single number", "1", true},
+		{"Invalid format", "not-a-version", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVersion(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateVersion(%s) error = %v, wantErr %v",
+					tt.version, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add 'sshsk update' command for self-updating the binary
- Always targets /usr/local/bin/sshsk for consistent system-wide updates
- Handles 'text file busy' error on Linux by renaming before replacing
- Automatic permission detection with sudo requirement messaging
- Downloads from GitHub releases with checksum verification
- Creates backup before update with automatic rollback on failure
- Skip Vault config validation for version and update commands
- Commands that work without VAULT_ADDR: version, update, help, completion